### PR TITLE
Add CLIENT_MAX_BODY_SIZE property

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ The directory to store Nginx log files. It defaults to `/var/log/nginx`.
 ##### `CONSUL_TEMPLATE_LOG_DIR`
 The directory to store Consul Template log files. It defaults to `/var/log/consul-template`.
 
+##### `CLIENT_MAX_BODY_SIZE`
+Sets the maximum allowed size of the client request body, specified in the “Content-Length” request header field. It defaults to `1m`.
+
 
 ## Volumes
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -25,6 +25,7 @@ server {
   access_log {{ env "NGINX_LOG_DIR" }}/access.log upstream_time;
   error_log {{ env "NGINX_LOG_DIR" }}/error.log;
   server_name {{ env "VIRTUAL_HOST" }};
+  client_max_body_size {{ env "CLIENT_MAX_BODY_SIZE" }};
 
   {{ $paramRegex := "{[\\w-]+}" }}
   {{ $allRegex := "<[\\w-]+>" }}

--- a/run.sh
+++ b/run.sh
@@ -13,6 +13,7 @@ export SERVICE_TAG="${SERVICE_TAG:-openlmis-service}"
 export RESOURCES_PATH="${RESOURCES_PATH:-resources}"
 export NGINX_LOG_DIR="${NGINX_LOG_DIR:-/var/log/nginx}"
 export CONSUL_TEMPLATE_LOG_DIR="${CONSUL_TEMPLATE_LOG_DIR:-/var/log/consul-template}"
+export CLIENT_MAX_BODY_SIZE="${CLIENT_MAX_BODY_SIZE:-1m}"
 
 # Run consul-template in background
 CONSUL_PATH="${CONSUL_HOST}:${CONSUL_PORT}"


### PR DESCRIPTION
It seems like sometimes a request that contain a requisition will have content length greater than 1MB (the default maximum value in the nginx). To avoid rebuilding the nginx image each time to change the value of the _client_max_body_size_ property we decided to create a related property in our .env file. The value of the property will be used by nginx and If it is not set the default value will be used.