### PR TITLE
Added ability to set timeout properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ The directory to store Consul Template log files. It defaults to `/var/log/consu
 ##### `CLIENT_MAX_BODY_SIZE`
 Sets the maximum allowed size of the client request body, specified in the “Content-Length” request header field. It defaults to `1m`.
 
+##### `PROXY_CONNECT_TIMEOUT`
+Defines a timeout for establishing a connection with a proxied server. It defaults to `60s`.
+
+##### `PROXY_SEND_TIMEOUT`
+Sets a timeout for transmitting a request to the proxied server. It defaults to `60s`.
+
+##### `PROXY_READ_TIMEOUT`
+Defines a timeout for reading a response from the proxied server. It defaults to `60s`.
+
+##### `SEND_TIMEOUT`
+Sets a timeout for transmitting a response to the client. It defaults to `60s`.
+
+##### `NGINX_TIMEOUT`
+If you want to set the same value for `PROXY_CONNECT_TIMEOUT`, `PROXY_SEND_TIMEOUT`, `PROXY_READ_TIMEOUT` and `SEND_TIMEOUT` you can use this variable instead.
+
 
 ## Volumes
 
@@ -90,7 +105,7 @@ docker run -d -v nginx-log:/var/log/nginx --name nginx openlmis/nginx
 docker run --rm -v nginx-log:/nginx-log openlmis/dev ls /nginx-log
 ```
 
-This: 
+This:
 
 1. creates a named volume `nginx-log` that nginx will write logs to
 2. runs nginx (this image) telling it to mount the named volume `nginx-log` to the nginx logging director

--- a/nginx.conf
+++ b/nginx.conf
@@ -26,6 +26,10 @@ server {
   error_log {{ env "NGINX_LOG_DIR" }}/error.log;
   server_name {{ env "VIRTUAL_HOST" }};
   client_max_body_size {{ env "CLIENT_MAX_BODY_SIZE" }};
+  proxy_connect_timeout {{ env "PROXY_CONNECT_TIMEOUT" }};
+  proxy_send_timeout {{ env "PROXY_SEND_TIMEOUT" }};
+  proxy_read_timeout {{ env "PROXY_READ_TIMEOUT" }};
+  send_timeout {{ env "SEND_TIMEOUT" }};
 
   {{ $paramRegex := "{[\\w-]+}" }}
   {{ $allRegex := "<[\\w-]+>" }}
@@ -33,7 +37,7 @@ server {
 
   {{ $paramReplace := "[\\w-]+" }}
   {{ $allReplace := ".+" }}
-  
+
   # First retrieve paths without parameters
   {{ range $resources }} {{ $location := .Key }} {{ $upstream := .Value }}
     {{- if not (or (regexMatch $paramRegex $location) (regexMatch $allRegex $location)) }}

--- a/run.sh
+++ b/run.sh
@@ -14,6 +14,10 @@ export RESOURCES_PATH="${RESOURCES_PATH:-resources}"
 export NGINX_LOG_DIR="${NGINX_LOG_DIR:-/var/log/nginx}"
 export CONSUL_TEMPLATE_LOG_DIR="${CONSUL_TEMPLATE_LOG_DIR:-/var/log/consul-template}"
 export CLIENT_MAX_BODY_SIZE="${CLIENT_MAX_BODY_SIZE:-1m}"
+export PROXY_CONNECT_TIMEOUT="${PROXY_CONNECT_TIMEOUT:-${NGINX_TIMEOUT:-60s}}"
+export PROXY_SEND_TIMEOUT="${PROXY_SEND_TIMEOUT:-${NGINX_TIMEOUT:-60s}}"
+export PROXY_READ_TIMEOUT="${PROXY_READ_TIMEOUT:-${NGINX_TIMEOUT:-60s}}"
+export SEND_TIMEOUT="${SEND_TIMEOUT:-${NGINX_TIMEOUT:-60s}}"
 
 # Run consul-template in background
 CONSUL_PATH="${CONSUL_HOST}:${CONSUL_PORT}"
@@ -27,4 +31,3 @@ consul-template \
 
 # Run nginx
 nginx -g 'daemon off;'
-


### PR DESCRIPTION
It seems like some requests need more time than default one minutes in nginx configuration. This pull request add ability to set four properties in the nginx. Also there is a fifth property that should be used if a user would like to set the same value for all properties to avoid duplication. If properties are not set default value will be used by nginx.

New properties:
- proxy_connect_timeout
- proxy_send_timeout
- proxy_read_timeout
- send_timeout